### PR TITLE
Implement forum-equipment integration with tagging and modal enhancements

### DIFF
--- a/src/components/forum/EquipmentTagger.tsx
+++ b/src/components/forum/EquipmentTagger.tsx
@@ -1,0 +1,154 @@
+import React, { useState, useEffect } from 'react';
+import { Search, X } from 'lucide-react';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { supabase } from '@/lib/supabase';
+import { useDebounce } from '@/hooks/useDebounce';
+
+interface Equipment {
+  id: string;
+  brand: string;
+  model: string;
+  category: string;
+  image_url?: string;
+}
+
+interface EquipmentTaggerProps {
+  selectedEquipment: Equipment[];
+  onEquipmentChange: (equipment: Equipment[]) => void;
+  maxItems?: number;
+}
+
+export default function EquipmentTagger({ 
+  selectedEquipment, 
+  onEquipmentChange, 
+  maxItems = 5 
+}: EquipmentTaggerProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Equipment[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const debouncedSearch = useDebounce(searchQuery, 300);
+
+  useEffect(() => {
+    if (debouncedSearch.trim().length >= 2) {
+      searchEquipment(debouncedSearch);
+    } else {
+      setSearchResults([]);
+    }
+  }, [debouncedSearch]);
+
+  const searchEquipment = async (query: string) => {
+    setIsSearching(true);
+    try {
+      const { data, error } = await supabase
+        .from('equipment')
+        .select('id, brand, model, category, image_url')
+        .or(`brand.ilike.%${query}%,model.ilike.%${query}%`)
+        .limit(10);
+
+      if (error) throw error;
+      
+      const filtered = data?.filter(item => 
+        !selectedEquipment.some(selected => selected.id === item.id)
+      ) || [];
+      
+      setSearchResults(filtered);
+    } catch (error) {
+      console.error('Error searching equipment:', error);
+      setSearchResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  const addEquipment = (equipment: Equipment) => {
+    if (selectedEquipment.length < maxItems) {
+      onEquipmentChange([...selectedEquipment, equipment]);
+      setSearchQuery('');
+      setSearchResults([]);
+    }
+  };
+
+  const removeEquipment = (equipmentId: string) => {
+    onEquipmentChange(selectedEquipment.filter(item => item.id !== equipmentId));
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <Input
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search equipment to tag..."
+          className="pl-10 bg-white/5 border-white/10"
+          disabled={selectedEquipment.length >= maxItems}
+        />
+      </div>
+
+      {searchResults.length > 0 && (
+        <ScrollArea className="h-32 border border-white/10 rounded-lg">
+          <div className="p-2 space-y-1">
+            {searchResults.map((equipment) => (
+              <Button
+                key={equipment.id}
+                variant="ghost"
+                className="w-full justify-start h-auto p-2"
+                onClick={() => addEquipment(equipment)}
+              >
+                <div className="flex items-center gap-2">
+                  {equipment.image_url && (
+                    <img 
+                      src={equipment.image_url} 
+                      alt={`${equipment.brand} ${equipment.model}`}
+                      className="w-8 h-8 object-cover rounded"
+                    />
+                  )}
+                  <div className="text-left">
+                    <div className="font-medium text-sm">
+                      {equipment.brand} {equipment.model}
+                    </div>
+                    <div className="text-xs text-gray-400 capitalize">
+                      {equipment.category.replace(/_/g, ' ')}
+                    </div>
+                  </div>
+                </div>
+              </Button>
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+
+      {selectedEquipment.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-sm text-gray-400">
+            Tagged Equipment ({selectedEquipment.length}/{maxItems})
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {selectedEquipment.map((equipment) => (
+              <Badge
+                key={equipment.id}
+                variant="secondary"
+                className="flex items-center gap-1 pr-1"
+              >
+                <span className="text-xs">
+                  {equipment.brand} {equipment.model}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-4 w-4 p-0 hover:bg-red-500/20"
+                  onClick={() => removeEquipment(equipment.id)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/forum/ForumThreadPreview.tsx
+++ b/src/components/forum/ForumThreadPreview.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Card } from '@/components/ui/card';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { MessageSquare, Eye, Heart } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+
+interface ForumThreadPreviewProps {
+  thread: {
+    id: string;
+    title: string;
+    tee_count: number;
+    reply_count: number;
+    view_count: number;
+    created_at: string;
+    category: {
+      name: string;
+      slug: string;
+    };
+    user: {
+      username: string;
+      avatar_url?: string;
+    };
+  };
+  onClick: () => void;
+}
+
+export default function ForumThreadPreview({ thread, onClick }: ForumThreadPreviewProps) {
+  return (
+    <Card 
+      className="bg-[#1a1a1a] border-white/10 p-4 hover:bg-[#1a1a1a]/80 transition-colors cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="flex items-start gap-3">
+        <Avatar className="h-8 w-8 flex-shrink-0">
+          <AvatarImage src={thread.user.avatar_url} />
+          <AvatarFallback className="bg-gradient-to-br from-green-400 to-blue-500 text-white text-xs">
+            {thread.user.username?.[0]?.toUpperCase() || '?'}
+          </AvatarFallback>
+        </Avatar>
+        
+        <div className="flex-1 min-w-0">
+          <h4 className="font-medium text-sm line-clamp-2 mb-1">
+            {thread.title}
+          </h4>
+          
+          <div className="flex items-center gap-2 text-xs text-gray-400 mb-2">
+            <Badge variant="secondary" className="text-xs px-2 py-0">
+              {thread.category.name}
+            </Badge>
+            <span>by {thread.user.username}</span>
+            <span>•</span>
+            <span>{formatDistanceToNow(new Date(thread.created_at), { addSuffix: true })}</span>
+          </div>
+          
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3 text-xs text-gray-400">
+              <span className="flex items-center gap-1">
+                <MessageSquare className="h-3 w-3" />
+                {thread.reply_count || 0}
+              </span>
+              <span className="flex items-center gap-1">
+                <Eye className="h-3 w-3" />
+                {thread.view_count || 0}
+              </span>
+            </div>
+            
+            <div className="flex items-center gap-1">
+              <Heart className="h-4 w-4 text-[#10B981]" />
+              <span className="text-xs font-medium text-[#10B981]">
+                {thread.tee_count || 0}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/forum/PostCard.tsx
+++ b/src/components/forum/PostCard.tsx
@@ -39,6 +39,8 @@ interface PostCardProps {
     };
     depth?: number;
   };
+  equipment?: any[];
+  onEquipmentClick?: (equipment: any) => void;
   threadLocked?: boolean;
   showActions?: boolean;
   onEdit?: () => void;
@@ -47,9 +49,11 @@ interface PostCardProps {
 
 export default function PostCard({ 
   post, 
+  equipment,
+  onEquipmentClick,
   threadLocked = false, 
-  showActions = true,
-  onEdit,
+  showActions = true, 
+  onEdit, 
   onDelete 
 }: PostCardProps) {
   const { user } = useAuth();
@@ -193,6 +197,22 @@ export default function PostCard({
           <div className="text-gray-100 mb-4">
             {renderContent(post.content)}
           </div>
+
+          {/* Equipment Tags */}
+          {equipment && equipment.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {equipment.map((eq) => (
+                <Badge
+                  key={eq.id}
+                  variant="outline"
+                  className="cursor-pointer hover:bg-white/10"
+                  onClick={() => onEquipmentClick?.(eq)}
+                >
+                  {eq.brand} {eq.model}
+                </Badge>
+              ))}
+            </div>
+          )}
 
           {/* Reactions - Split Layout */}
           <div className="flex items-center justify-between">

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/supabase/forum-equipment-integration.sql
+++ b/supabase/forum-equipment-integration.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS forum_equipment_tags (
+  id UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+  post_id UUID REFERENCES forum_posts(id) ON DELETE CASCADE,
+  equipment_id UUID REFERENCES equipment(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(post_id, equipment_id)
+);
+
+ALTER TABLE forum_threads ADD COLUMN IF NOT EXISTS tee_count INTEGER DEFAULT 0;
+
+-- Create indexes for performance
+CREATE INDEX IF NOT EXISTS idx_forum_equipment_tags_equipment_id ON forum_equipment_tags(equipment_id);
+CREATE INDEX IF NOT EXISTS idx_forum_equipment_tags_post_id ON forum_equipment_tags(post_id);
+CREATE INDEX IF NOT EXISTS idx_forum_threads_tee_count ON forum_threads(tee_count);
+
+-- RLS Policies
+ALTER TABLE forum_equipment_tags ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Equipment tags are viewable by everyone" ON forum_equipment_tags
+  FOR SELECT USING (true);
+
+CREATE POLICY "Users can tag equipment in own posts" ON forum_equipment_tags
+  FOR INSERT WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM forum_posts 
+      WHERE id = post_id AND user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can remove equipment tags from own posts" ON forum_equipment_tags
+  FOR DELETE USING (
+    EXISTS (
+      SELECT 1 FROM forum_posts 
+      WHERE id = post_id AND user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
# Implement forum-equipment integration with tagging and modal enhancements

## Summary

This PR implements a comprehensive forum-equipment integration system that allows users to tag equipment in forum posts and view forum discussions about specific equipment. The integration includes:

**Database Changes:**
- New `forum_equipment_tags` table linking forum posts to equipment
- Added `tee_count` column to `forum_threads` for popularity sorting
- Proper RLS policies and performance indexes

**New Components:**
- `EquipmentTagger`: Search and tag equipment in forum posts (max 5 items)
- `ForumThreadPreview`: Compact thread cards for equipment modal display
- `useDebounce` hook for search functionality

**Major UI Changes:**
- Replaced "Specifications" tab with "Forums" tab in `EquipmentShowcaseModal`
- Added equipment badges to forum posts in `PostCard`
- Integrated equipment tagging into forum post creation workflow

**Service Layer:**
- `getForumThreadsByEquipment()`: Fetch forum discussions about specific equipment
- `tagEquipmentInPost()`: Add/remove equipment tags from posts  
- `getEquipmentTagsForPost()`: Retrieve equipment tags for display

## Review & Testing Checklist for Human

⚠️ **Critical Risk**: I was unable to test these changes locally due to missing Supabase environment variables, so runtime testing is essential.

- [ ] **Apply database schema**: Run `supabase/forum-equipment-integration.sql` on the database before testing
- [ ] **Test equipment tagging flow**: Create a new forum post, search for equipment, tag 2-3 items, verify they appear as badges
- [ ] **Test Forums tab in equipment modal**: Open any equipment from a bag, verify Forums tab loads discussions and navigation works
- [ ] **Verify TypeScript compilation**: Ensure `npm run build` passes without errors in your environment
- [ ] **Test equipment badge navigation**: Click equipment badges in forum posts to verify they open the equipment modal correctly

**Recommended Test Plan:**
1. Apply database migrations first
2. Create a test forum post with equipment tags
3. Navigate to an equipment item and verify forum discussions appear
4. Test bidirectional navigation between forum posts and equipment modals

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    DB[("forum_equipment_tags<br/>Database Table")]:::major-edit
    
    Modal["EquipmentShowcaseModal<br/>(Forums Tab)"]:::major-edit
    Tagger["EquipmentTagger<br/>(New Component)"]:::major-edit
    Preview["ForumThreadPreview<br/>(New Component)"]:::major-edit
    
    PostCard["PostCard<br/>(Equipment Badges)"]:::minor-edit
    ThreadView["ThreadView<br/>(Integration)"]:::minor-edit
    ForumService["forum.ts<br/>(New Functions)"]:::major-edit
    
    Debounce["useDebounce<br/>(New Hook)"]:::minor-edit
    
    Modal --> Preview
    Modal --> ForumService
    Tagger --> Debounce
    Tagger --> ForumService
    ThreadView --> Tagger
    PostCard --> Modal
    ForumService --> DB
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Link**: https://app.devin.ai/sessions/6ea1f80c5c5942928168849b076040d9
- **Requested by**: @brettericmartin
- The complex Supabase queries in `getForumThreadsByEquipment()` should be tested carefully for performance and correctness
- Navigation paths assume forum routing structure `/forum/{category}/{threadId}` - verify this matches your actual routes
- Equipment search in `EquipmentTagger` uses `ilike` queries which should work with PostgreSQL but may need adjustment for other databases